### PR TITLE
Support reading Kaldi compressed egs

### DIFF
--- a/pkwrap/script_utils.py
+++ b/pkwrap/script_utils.py
@@ -162,6 +162,32 @@ def get_egs_info(egs_dir):
 
     return num_archives
 
+def egs_reader(egs_rspec):
+    """Read a compressed examples (cegs) file in kaldi
+
+    This function is useful for reading the features and keys
+    for decoding the validation set.
+
+    Args:
+        egs_rspec: a rspecifier as the ones used in Kaldi. For example, if it is
+            a validation diagnostic compressed egs file we may specify it as
+
+            ```
+            ark:/path/to/valid_diagnostic.cegs
+            ```
+    Returns:
+        an iterable to iterate over each (key, utterance) tuple in egs_rspec
+    """
+    reader = kaldi.nnet3.SequentialNnetChainExampleReader(egs_rspec);
+    return reader
+
+def egs_reader_gen(egs_rspec):
+    """A generator function that calls compressed feat_reader to return pytorch Tensors"""
+    reader = egs_reader(egs_rspec)
+    while not reader.Done():
+        yield reader.Key(), kaldi.chain.GetFeaturesFromCompressedEgs(reader.Value())
+        reader.Next()
+
 def feat_reader(feature_rspec):
     """Read a matrix scp file in kaldi
 

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -58,6 +58,11 @@ kaldi::chain::Supervision ReadSupervisionFromFile(std::string &file_name) {
     return sup;
 }
 
+void PrintSupervisionInfoE2E(const kaldi::chain::Supervision &supervision) {
+    std::cout << "Number of sequences: " << supervision.num_sequences << "\n";
+    std::cout << "Number of frames per sequence " << supervision.frames_per_sequence << "\n";
+}
+
 // TODO, DONE: 6/8
 // 7. Check derivative size
 /* // 8. Check xent_deriv_size */
@@ -401,6 +406,18 @@ int32 ExampleMergingConfig::MinibatchSize(int32 size_of_eg,
 }
 
 torch::Tensor GetFeaturesFromEgs(const kaldi::nnet3::NnetChainExample &egs) {
+    auto mat = egs.inputs[0].features.GetFullMatrix();
+    int32 mb_size = egs.outputs[0].supervision.num_sequences;
+    int32 feat_dim = mat.NumCols();
+    return KaldiMatrixToTensor(mat).clone().detach().reshape({mb_size, -1, feat_dim});
+}
+
+torch::Tensor GetFeaturesFromCompressedEgs(kaldi::nnet3::NnetChainExample &egs) {
+    if(egs.inputs.size() != 1) {
+        std::cout << "We do not support the egs to have more than 1 input features" << std::endl;
+        exit(1);
+    }
+    egs.inputs[0].features.Uncompress();
     auto mat = egs.inputs[0].features.GetFullMatrix();
     int32 mb_size = egs.outputs[0].supervision.num_sequences;
     int32 feat_dim = mat.NumCols();

--- a/src/chain.h
+++ b/src/chain.h
@@ -23,6 +23,7 @@ kaldi::chain::DenominatorGraph LoadDenominatorGraph(std::string fst_path, int32 
 bool TestLoadDenominatorGraph(std::string fst_path, int32 num_pdfs);
 kaldi::chain::Supervision ReadOneSupervisionFile(std::string &file_name);
 kaldi::chain::Supervision ReadSupervisionFromFile(std::string &file_name);
+void PrintSupervisionInfoE2E(const kaldi::chain::Supervision &supervision);
 bool ComputeChainObjfAndDeriv(const kaldi::chain::ChainTrainingOptions &opts,
                               const kaldi::chain::DenominatorGraph &den_graph,
                               const kaldi::chain::Supervision &supervision,
@@ -153,6 +154,7 @@ MapType eg_to_egs_;
 
 int32 GetNnetChainExampleSize(const kaldi::nnet3::NnetChainExample &a);
 torch::Tensor GetFeaturesFromEgs(const kaldi::nnet3::NnetChainExample &egs);
+torch::Tensor GetFeaturesFromCompressedEgs(kaldi::nnet3::NnetChainExample &egs);
 torch::Tensor GetIvectorsFromEgs(const kaldi::nnet3::NnetChainExample &egs);
 int32 GetFramesPerSequence(const kaldi::nnet3::NnetChainExample &egs);
 kaldi::chain::Supervision GetSupervisionFromEgs(kaldi::nnet3::NnetChainExample &egs);

--- a/src/pkwrap-main.h
+++ b/src/pkwrap-main.h
@@ -43,6 +43,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("Close", &kaldi::BaseFloatMatrixWriter::Close);
 
     auto nnet3 = kaldi_module.def_submodule("nnet3");
+    py::class_<kaldi::nnet3::SequentialNnetChainExampleReader>(nnet3, "SequentialNnetChainExampleReader")
+        .def(py::init<std::string>())
+        .def("Next", &kaldi::nnet3::SequentialNnetChainExampleReader::Next)
+        .def("Done", &kaldi::nnet3::SequentialNnetChainExampleReader::Done)
+        .def("Key", &kaldi::nnet3::SequentialNnetChainExampleReader::Key)
+        .def("Value", &kaldi::nnet3::SequentialNnetChainExampleReader::Value);
     py::class_<kaldi::nnet3::OnlineNaturalGradient>(nnet3, "OnlineNaturalGradient")
         .def(py::init<>())
         .def("SetRank", &kaldi::nnet3::OnlineNaturalGradient::SetRank)
@@ -79,8 +85,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     chain.def("MergeChainEgs", &MergeChainEgs);
     chain.def("ShiftEgsVector", &ShiftEgsVector);
     chain.def("GetFeaturesFromEgs", &GetFeaturesFromEgs);
+    chain.def("GetFeaturesFromCompressedEgs", &GetFeaturesFromCompressedEgs);
     chain.def("GetIvectorsFromEgs", &GetIvectorsFromEgs);
     chain.def("GetFramesPerSequence", &GetFramesPerSequence);
     chain.def("GetSupervisionFromEgs", &GetSupervisionFromEgs);
+    chain.def("PrintSupervisionInfoE2E", &PrintSupervisionInfoE2E);
 }
 #endif


### PR DESCRIPTION
This PR adds functions to support Kaldi compressed egs. 
This can be used for reading the diagnostic cegs generated by kaldi and evaluated validation loss on it.
This can also be used to read and decode validation diagnostics for early stopping.