### PR TITLE
Test compilation with a recent Kaldi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,10 @@ from torch.utils import cpp_extension
 
 import torch
 PYTORCH_VERSION = torch.__version__
+SUPPORTED_PYTORCH_MAJOR_VER = 1
+SUPPORTED_PYTORCH_MINOR_VER = 11
 PYTORCH_MAJOR_VER, PYTORCH_MIN_VER = list(map(int, PYTORCH_VERSION.split('.')[:2]))
-if PYTORCH_MAJOR_VER != 1 or PYTORCH_MIN_VER > 8:
+if PYTORCH_MAJOR_VER != SUPPORTED_PYTORCH_MAJOR_VER or PYTORCH_MIN_VER > SUPPORTED_PYTORCH_MINOR_VER:
     sys.stderr.write("We support pytorch version until 1.8 only\n")
     quit(1)
 

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -217,7 +217,7 @@ void ChainExampleMerger::AcceptExample(kaldi::nnet3::NnetChainExample *eg) {
   // element of the vector.
   std::vector<kaldi::nnet3::NnetChainExample*> &vec = eg_to_egs_[eg];
   vec.push_back(eg);
-  int32 eg_size = GetNnetChainExampleSize(*eg),
+  int32 eg_size = GetNnetChainExampleSizeInternal(*eg),
       num_available = vec.size();
   bool input_ended = false;
   int32 minibatch_size = config_.MinibatchSize(eg_size, num_available,
@@ -239,7 +239,7 @@ void ChainExampleMerger::AcceptExample(kaldi::nnet3::NnetChainExample *eg) {
 
 void ChainExampleMerger::WriteMinibatch(
     std::vector<kaldi::nnet3::NnetChainExample> *egs) {
-  int32 eg_size = GetNnetChainExampleSize((*egs)[0]);
+  int32 eg_size = GetNnetChainExampleSizeInternal((*egs)[0]);
   kaldi::nnet3::NnetChainExampleStructureHasher eg_hasher;
   size_t structure_hash = eg_hasher((*egs)[0]);
   int32 minibatch_size = egs->size();
@@ -266,7 +266,7 @@ void ChainExampleMerger::Finish() {
   for (size_t i = 0; i < all_egs.size(); i++) {
     int32 minibatch_size;
     std::vector<kaldi::nnet3::NnetChainExample*> &vec = all_egs[i];
-    int32 eg_size = GetNnetChainExampleSize(*(vec[0]));
+    int32 eg_size = GetNnetChainExampleSizeInternal(*(vec[0]));
     bool input_ended = true;
     while (!vec.empty() &&
            (minibatch_size = config_.MinibatchSize(eg_size, vec.size(),
@@ -283,7 +283,7 @@ void ChainExampleMerger::Finish() {
       WriteMinibatch(&egs_to_merge);
     }
     if (!vec.empty()) {
-      int32 eg_size = GetNnetChainExampleSize(*(vec[0]));
+      int32 eg_size = GetNnetChainExampleSizeInternal(*(vec[0]));
       kaldi::nnet3::NnetChainExampleStructureHasher eg_hasher;
       size_t structure_hash = eg_hasher(*(vec[0]));
       int32 num_discarded = vec.size();
@@ -296,7 +296,7 @@ void ChainExampleMerger::Finish() {
   stats_.PrintStats();
 }
 
-int32 GetNnetChainExampleSize(const kaldi::nnet3::NnetChainExample &a) {
+int32 GetNnetChainExampleSizeInternal(const kaldi::nnet3::NnetChainExample &a) {
   int32 ans = 0;
   for (size_t i = 0; i < a.inputs.size(); i++) {
     int32 s = a.inputs[i].indexes.size();

--- a/src/chain.h
+++ b/src/chain.h
@@ -162,7 +162,7 @@ class ChainExampleMerger {
 MapType eg_to_egs_;
 };
 
-int32 GetNnetChainExampleSize(const kaldi::nnet3::NnetChainExample &a);
+int32 GetNnetChainExampleSizeInternal(const kaldi::nnet3::NnetChainExample &a);
 torch::Tensor GetFeaturesFromEgs(const kaldi::nnet3::NnetChainExample &egs);
 torch::Tensor GetFeaturesFromCompressedEgs(kaldi::nnet3::NnetChainExample &egs);
 torch::Tensor GetIvectorsFromEgs(const kaldi::nnet3::NnetChainExample &egs);


### PR DESCRIPTION
This PR resolves to aim issue mentioned in #26. ``GetNnetChainExampleSize`` is now renamed to ``GetNnetChainExampleSizeInternal`` because there is a conflicting name now in Kaldi, which does the exact same thing. We cannot reuse the Kaldi version because it would break compilation for older versions (pre-Dec 31 2022).